### PR TITLE
Fixed JS error on framework 5.0.14 on tickets without article

### DIFF
--- a/var/httpd/htdocs/js/Core.Agent.Znuny4OTRSMarkTicketSeenUnseen.js
+++ b/var/httpd/htdocs/js/Core.Agent.Znuny4OTRSMarkTicketSeenUnseen.js
@@ -47,8 +47,8 @@ Core.Agent.Znuny4OTRSMarkTicketSeenUnseen = (function (TargetNS) {
 
     TargetNS.AgentTicketMarkSeenUnseen = function (Param) {
 
-        // check if at least one article is exists
-        if ($('#ArticleItems div a').length == 0){
+        // check if at least one article exists
+        if ($('#ArticleItems div ul li a').length == 0){
             return;
         }
 


### PR DESCRIPTION
Somewhere between 5.0.9 and 5.0.14 the dom-structure for the article tree changed. With the old selector there are now 3 found hits (console.log the length) even if no article exists (check easily with process tickets).