### PR TITLE
Replace ArticleIndex() with ArticleList()

### DIFF
--- a/Kernel/Modules/AgentTicketMarkSeenUnseen.pm
+++ b/Kernel/Modules/AgentTicketMarkSeenUnseen.pm
@@ -60,9 +60,14 @@ sub Run {
         );
     }
 
-    my @ArticleIDs = $ArticleObject->ArticleIndex(
+    my @Articles = $ArticleObject->ArticleList(
         TicketID => $GetParam{TicketID},
     );
+    
+    my @ArticleIDs = ();
+    foreach my $Article (@Articles) {
+        push(@ArticleIDs, $Article->{ArticleID});
+    }
 
     if ( $GetParam{ArticleID} ) {
         if ( !scalar grep { $GetParam{ArticleID} eq $_ } @ArticleIDs ) {


### PR DESCRIPTION
Using ArticleList() as described in https://doc.znuny.org/doc/manual/developer/stable/en/html/package-porting.html
This fix allows to also use this Package with OTOBO after doing a `Dev::Tools::Migrate::OTRSToOTOBO --cleanall`
Without this modification the use of this plugin resulted in an Internal Server Error: `Can't locate object method "ArticleIndex" via package "Kernel::System::Ticket::Article"`.